### PR TITLE
Fix the correct python exectuable in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ python ./calib/calib.py
 
 **[4]** Run augmented stacking:
 ```bash
-python ./calib/calib.py
+python ./augmented_stacking.py
 ```
 
 ## Credits


### PR DESCRIPTION
I have the impression that users should execute `augmented_stacking.py` to run the main program (and not calib.py). Please check!